### PR TITLE
Remove blueprints from views

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+layout python

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ cache:
 
 env:
   matrix:
-    - REQUIREMENTS=devel EXTRAS=all
+    - REQUIREMENTS=release EXTRAS=tests
 
 python:
   - "3.6"

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+include *.sh
+include pytest.ini
+include .envrc

--- a/oarepo_heartbeat/__init__.py
+++ b/oarepo_heartbeat/__init__.py
@@ -11,4 +11,5 @@ environ_probe = signal('oarepo.probe.environ')
 environ_probe.connect(gather_libraries)
 environ_probe.connect(gather_python)
 
-__all__ = ('__version__', 'liveliness_probe', 'readiness_probe', 'environ_probe')
+__all__ = ('__version__', 'liveliness_probe',
+           'readiness_probe', 'environ_probe')

--- a/oarepo_heartbeat/version.py
+++ b/oarepo_heartbeat/version.py
@@ -1,3 +1,3 @@
 from __future__ import absolute_import, print_function
 
-__version__ = "1.0.0"
+__version__ = "1.0.1"

--- a/oarepo_heartbeat/views.py
+++ b/oarepo_heartbeat/views.py
@@ -1,29 +1,24 @@
 import json
 
-from flask import Blueprint, jsonify, current_app
+from flask import jsonify, current_app
 
 from oarepo_heartbeat import readiness_probe, liveliness_probe, environ_probe
 
-blueprint = Blueprint('oarepo-heartbeat', __name__, url_prefix='/.well-known/heartbeat')
 
-
-@blueprint.route('/readiness')
 def readiness():
-    data = [x[1] for x in readiness_probe.send(blueprint)]
+    data = [x[1] for x in readiness_probe.send()]
     return _collect_results(*data)
 
 
-@blueprint.route('/liveliness')
 def liveliness():
-    data = [x[1] for x in liveliness_probe.send(blueprint)]
+    data = [x[1] for x in liveliness_probe.send()]
     return _collect_results(*data)
 
 
-@blueprint.route('/environ')
 def environ():
     data = {}
     total_status = True
-    for x in environ_probe.send(blueprint):
+    for x in environ_probe.send():
         status, values = x[1]
         total_status &= status
         data.update(values)

--- a/oarepo_heartbeat/views.py
+++ b/oarepo_heartbeat/views.py
@@ -1,8 +1,8 @@
 import json
 
-from flask import jsonify, current_app
+from flask import current_app
 
-from oarepo_heartbeat import readiness_probe, liveliness_probe, environ_probe
+from oarepo_heartbeat import environ_probe, liveliness_probe, readiness_probe
 
 
 def readiness():

--- a/setup.py
+++ b/setup.py
@@ -4,10 +4,13 @@ from setuptools import find_packages, setup
 
 readme = open('README.rst').read()
 
-tests_require = [
-]
+tests_require = []
 
 extras_require = {
+    'tests': [
+        *tests_require,
+        'oarepo[tests-es7]'
+    ]
 }
 
 setup_requires = [
@@ -15,6 +18,8 @@ setup_requires = [
 ]
 
 install_requires = [
+    'blinker',
+    'Flask',
     'pip>=6.0.0'
 ]
 


### PR DESCRIPTION
We don't need blueprints as they are not used in the current `oarepo-micro-api` module routing.